### PR TITLE
Update basic epidatr&epidatpy usage, remove covidcast packages

### DIFF
--- a/basic.R
+++ b/basic.R
@@ -1,10 +1,15 @@
 library(magrittr) # for `%>%`
 
+# Enable caching of some version history queries:
+epidatr::set_cache()
+
 # Fetch daily HHS hospitalization count data for all states and territories for
 # April 2022 using `epidatr`:
 april = epidatr::pub_covidcast(
-  "hhs", "confirmed_admissions_influenza_1d",
-  "state", "day",
+  source = "hhs",
+  signals = "confirmed_admissions_influenza_1d",
+  geo_type = "state",
+  time_type = "day",
   geo_values = "*",
   time_values = epidatr::epirange(20220401, 20220430)
 )
@@ -17,14 +22,6 @@ april_as_of_may10 =
   epidatr::pub_covidcast(
     "hhs", "confirmed_admissions_influenza_1d",
     "state", "day",
-    "*",
-    epidatr::epirange(20220401, 20220430),
+    "*", epidatr::epirange(20220401, 20220430),
     as_of = 20220510
   )
-
-# Fetch the first data set using the older `covidcast` package:
-april_with_covidcast = covidcast::covidcast_signal(
-  "hhs", "confirmed_admissions_influenza_1d",
-  as.Date("2022-04-01"), as.Date("2022-04-30"),
-  "state", "*"
-)

--- a/basic.py
+++ b/basic.py
@@ -2,29 +2,33 @@ import datetime
 
 import pandas as pd
 
-import epidatpy.request
-import covidcast
+from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+
+# All calls using the `epidata` object will now be cached for a day
+epidata = EpiDataContext(use_cache=True, cache_max_age_days=1)
 
 # Fetch daily HHS hospitalization count data for all states and territories for
 # April 2022 using `epidatpy`, a draft new client package for accessing the
 # Delphi Epidata API:
-cce = epidatpy.request.CovidcastEpidata()
-april = cce[("hhs", "confirmed_admissions_influenza_1d")].call(
-    "state", "*",
-    epidatpy.request.EpiRange(20220401, 20220430)
+april = epidata.pub_covidcast(
+    data_source = "hhs",
+    signals = "confirmed_admissions_influenza_1d",
+    geo_type = "nation",
+    time_type = "day",
+    geo_values = "*",
+    time_values = EpiRange(20220401, 20220430)
 ).df()
+# (You can also use `time_values = "*"` to get data for all times, or
+# `time_values = array_of_dates` to get data for those dates.)
 
 # Fetch these measurements as they were reported on May 10, rather than the
 # current version:
-april_as_of_may10 = cce[("hhs", "confirmed_admissions_influenza_1d")].call(
-    "state", "*",
-    epidatpy.request.EpiRange(20220401, 20220430),
+april_as_of_may10 = epidata.pub_covidcast(
+    data_source = "hhs",
+    signals = "confirmed_admissions_influenza_1d",
+    geo_type = "nation",
+    time_type = "day",
+    geo_values = "*",
+    time_values = EpiRange(20220401, 20220430),
     as_of = 20220510
 ).df()
-
-# Fetch the first data set using the older `covidcast` package:
-april_with_covidcast = covidcast.signal(
-  "hhs", "confirmed_admissions_influenza_1d",
-  datetime.date(2022, 4, 1), datetime.date(2022, 4, 30),
-  "state", "*"
-)

--- a/basic.py
+++ b/basic.py
@@ -4,12 +4,11 @@ import pandas as pd
 
 from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
 
-# All calls using the `epidata` object will now be cached for a day
+# All calls using the `epidata` object will be cached for a day
 epidata = EpiDataContext(use_cache=True, cache_max_age_days=1)
 
 # Fetch daily HHS hospitalization count data for all states and territories for
-# April 2022 using `epidatpy`, a draft new client package for accessing the
-# Delphi Epidata API:
+# April 2022:
 april = epidata.pub_covidcast(
     data_source = "hhs",
     signals = "confirmed_admissions_influenza_1d",

--- a/install_dependencies_for_R.R
+++ b/install_dependencies_for_R.R
@@ -1,3 +1,2 @@
 install.packages("remotes")
 remotes::install_github("cmu-delphi/epidatr")
-remotes::install_github("cmu-delphi/covidcast", subdir="R-packages/covidcast")

--- a/install_dependencies_for_python.sh
+++ b/install_dependencies_for_python.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
 pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
-pip install covidcast


### PR DESCRIPTION
Updating snippets for package updates.  This will require another pass later to update them for however the new NHSN data will work plus for getting the weekly data. 